### PR TITLE
Set API key for VOD request

### DIFF
--- a/AdvancedExample/app/src/main/java/com/google/ads/interactivemedia/v3/samples/videoplayerapp/SampleAdsWrapper.java
+++ b/AdvancedExample/app/src/main/java/com/google/ads/interactivemedia/v3/samples/videoplayerapp/SampleAdsWrapper.java
@@ -147,7 +147,7 @@ public class SampleAdsWrapper implements AdEvent.AdEventListener, AdErrorEvent.A
                     videoListItem.getApiKey(), mDisplayContainer);
         } else { // VOD request.
             request = mSdkFactory.createVodStreamRequest(videoListItem.getContentSourceId(),
-                    videoListItem.getVideoId(), null, mDisplayContainer);
+                    videoListItem.getVideoId(), videoListItem.getApiKey(), mDisplayContainer);
         }
         // Set the stream format (HLS or DASH).
         request.setFormat(videoListItem.getStreamFormat());


### PR DESCRIPTION
The buildStreamRequest function was passing a null API Key for each request.